### PR TITLE
設定画面が2つ以上作られないようにする変更が初期設定の取得に失敗していたので修正。

### DIFF
--- a/sikusiSubtitles/MainWindow.xaml.cs
+++ b/sikusiSubtitles/MainWindow.xaml.cs
@@ -32,12 +32,14 @@ namespace sikusiSubtitles {
         public MainWindow() {
             InitializeComponent();
 
-            // サービスとメニュー・設定画面を作成
+            // サービスの作成
             CreateServices();
-            CreateMenuAndSettingPages();
 
             // 設定をロード
             LoadSettings();
+
+            // メニューと設定画面の作成
+            CreateMenuAndSettingPages();
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e) {

--- a/sikusiSubtitles/OBS/ObsService.cs
+++ b/sikusiSubtitles/OBS/ObsService.cs
@@ -35,7 +35,9 @@ namespace sikusiSubtitles.OBS {
             obsButton.Checked += obsButton_Checked;
             obsButton.Unchecked += obsButton_Unchecked;
             serviceManager.AddTopFlowControl(obsButton, 200);
+        }
 
+        public override void Init() {
             settingsPage = new ObsPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/OBS/ObsSubtitlesService.cs
+++ b/sikusiSubtitles/OBS/ObsSubtitlesService.cs
@@ -16,8 +16,7 @@ namespace sikusiSubtitles.OBS {
         public string VoiceTarget { get; set; } = "";
         public List<string> TranslateTargetList { get; set; } = new List<string>();
 
-        public ObsSubtitlesService(ServiceManager serviceManager) : base(serviceManager, ObsServiceManager.ServiceName, "ObsSubtitles", "字幕", 200) {
-            settingsPage = new ObsSubtitlesPage(ServiceManager, this);
+        public ObsSubtitlesService(ServiceManager serviceManager) : base(serviceManager, SubtitlesServiceManager.ServiceName, "ObsSubtitles", "OBS", 200) {
         }
 
         // Services
@@ -27,6 +26,8 @@ namespace sikusiSubtitles.OBS {
         private Dictionary<string, string> previousTexts = new Dictionary<string, string>();
 
         public override void Init() {
+            settingsPage = new ObsSubtitlesPage(ServiceManager, this);
+
             obsService = ServiceManager.GetService<ObsService>();
             if (obsService != null) {
                 obsService.ConnectionChanged += ObsConnectionChanged;

--- a/sikusiSubtitles/OCR/AzureOcrService.cs
+++ b/sikusiSubtitles/OCR/AzureOcrService.cs
@@ -19,6 +19,9 @@ namespace sikusiSubtitles.OCR {
 
 
         public AzureOcrService(ServiceManager serviceManager) : base(serviceManager, "AzureOcr", "Azure Cognitive Services", 300) {
+        }
+
+        public override void Init() {
             settingsPage = new AzureOcrPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/OCR/OcrServiceManager.cs
+++ b/sikusiSubtitles/OCR/OcrServiceManager.cs
@@ -26,7 +26,15 @@ namespace sikusiSubtitles.OCR {
         private Shortcut.Shortcut clearObsTextShortcut = new Shortcut.Shortcut("clear-obs-text", "OCR", "OCRの翻訳結果をクリアする", "");
 
         public OcrServiceManager(ServiceManager serviceManager) : base(serviceManager, ServiceName, ServiceName, "OCR", 500, true) {
+        }
+
+        public override void Init() {
             settingsPage = new OcrPage(ServiceManager, this);
+            var shortcutService = this.ServiceManager.GetService<ShortcutService>();
+            if (shortcutService != null) {
+                shortcutService.Shortcuts.Add(ocrShortcut);
+                shortcutService.Shortcuts.Add(clearObsTextShortcut);
+            }
         }
 
         public override void Load(JToken token) {
@@ -54,14 +62,6 @@ namespace sikusiSubtitles.OCR {
                 new JProperty("OcrShortcutKey", ocrShortcut.ShortcutKey),
                 new JProperty("ClearObsTextShortcutKey", clearObsTextShortcut.ShortcutKey)
             };
-        }
-
-        public override void Init() {
-            var shortcutService = this.ServiceManager.GetService<ShortcutService>();
-            if (shortcutService != null) {
-                shortcutService.Shortcuts.Add(ocrShortcut);
-                shortcutService.Shortcuts.Add(clearObsTextShortcut);
-            }
         }
 
         public OcrService? GetOcrEngine() {

--- a/sikusiSubtitles/OCR/TesseractOcrService.cs
+++ b/sikusiSubtitles/OCR/TesseractOcrService.cs
@@ -15,7 +15,9 @@ using Tesseract;
 namespace sikusiSubtitles.OCR {
     public class TesseractOcrService : OcrService {
         public TesseractOcrService(ServiceManager serviceManager) : base(serviceManager, "Tesseract", "Tesseract", 200) {
-            // 設定ぺーいj
+        }
+
+        public override void Init() {
             settingsPage = new TesseractOcrPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/OCR/WindowsOcrService.cs
+++ b/sikusiSubtitles/OCR/WindowsOcrService.cs
@@ -19,7 +19,9 @@ namespace sikusiSubtitles.OCR {
         public WindowsOcrService(ServiceManager serviceManager) : base(serviceManager, "WIndowsOCR", "Windows標準", 100) {
             availableLanguages = OcrEngine.AvailableRecognizerLanguages;
             languages = availableLanguages.Select(lang => new Language(lang.LanguageTag, lang.DisplayName)).ToList();
+        }
 
+        public override void Init() {
             settingsPage = new WindowsOcrPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/Shortcut/ShortcutService.cs
+++ b/sikusiSubtitles/Shortcut/ShortcutService.cs
@@ -62,12 +62,10 @@ namespace sikusiSubtitles.Shortcut {
             Shortcuts = new List<Shortcut>();
 
             CreateKeyNames();
-
-            // 設定ページ
-            settingsPage = new ShortcutPage(ServiceManager, this);
         }
 
         public override void Init() {
+            settingsPage = new ShortcutPage(ServiceManager, this);
             Start();
         }
 

--- a/sikusiSubtitles/Speech/SapiSpeechService.cs
+++ b/sikusiSubtitles/Speech/SapiSpeechService.cs
@@ -25,7 +25,9 @@ namespace sikusiSubtitles.Speech {
             foreach (var voice in voices2) {
                 this.voices.Add(new Voice("SAPI", voice.VoiceInfo.Id, voice.VoiceInfo.Name, voice.VoiceInfo.Culture.Name, voice.VoiceInfo.Gender.ToString()));
             }
+        }
 
+        public override void Init() {
             settingsPage = new SystemSpeechPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/Speech/VoiceVoxSpeechService.cs
+++ b/sikusiSubtitles/Speech/VoiceVoxSpeechService.cs
@@ -36,8 +36,9 @@ namespace sikusiSubtitles.Speech {
 
         public VoiceVoxSpeechService(ServiceManager serviceManager) : base(serviceManager, "VOICEVOX", "VOICEVOX", 500) {
             Task task = GetSpeakers();
+        }
 
-            // 設定ページ
+        public override void Init() {
             settingsPage = new VoiceVoxSpeechPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/SpeechRecognition/AmiVoiceSpeechRecognitionService.cs
+++ b/sikusiSubtitles/SpeechRecognition/AmiVoiceSpeechRecognitionService.cs
@@ -27,6 +27,9 @@ namespace sikusiSubtitles.SpeechRecognition {
         }
 
         public AmiVoiceSpeechRecognitionService(ServiceManager serviceManager) : base(serviceManager, "AmiVoice", "AmiVoice", 300) {
+        }
+
+        public override void Init() {
             settingsPage = new AmiVoiceSpeechRecognitionPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/SpeechRecognition/AzureSpeechRecognitionService.cs
+++ b/sikusiSubtitles/SpeechRecognition/AzureSpeechRecognitionService.cs
@@ -19,6 +19,9 @@ namespace sikusiSubtitles.SpeechRecognition {
         public string Region { get; set; } = "";
 
         public AzureSpeechRecognitionService(ServiceManager serviceManager) : base(serviceManager, "AzureSpeechRecognition", "Azure Cognitive Services", 200) {
+        }
+
+        public override void Init() {
             settingsPage = new AzureSpeechRecognitionPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/SpeechRecognition/ChromeSpeechRecognitionService.cs
+++ b/sikusiSubtitles/SpeechRecognition/ChromeSpeechRecognitionService.cs
@@ -19,6 +19,9 @@ namespace sikusiSubtitles.SpeechRecognition {
         ChromeSpeechRecognitionWebSocketServer? webSocketServer;
 
         public ChromeSpeechRecognitionService(ServiceManager serviceManager) : base(serviceManager, "ChromeSpeechRecognition", "Google Chrome", 100) {
+        }
+
+        public override void Init() {
             settingsPage = new ChromeSpeechRecognitionPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/SpeechRecognition/SpeechRecognitionServiceManager.cs
+++ b/sikusiSubtitles/SpeechRecognition/SpeechRecognitionServiceManager.cs
@@ -55,13 +55,11 @@ namespace sikusiSubtitles.SpeechRecognition {
             // マイク設定
             var enumerator = new MMDeviceEnumerator();
             Device = enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Console);
-
-            // 設定ページ
-            settingsPage = new SpeechRecognitionPage(ServiceManager, this);
         }
 
         public override void Init()
         {
+            settingsPage = new SpeechRecognitionPage(ServiceManager, this);
             speechRecognitionServices = ServiceManager.GetServices<SpeechRecognitionService>();
         }
 

--- a/sikusiSubtitles/Subtitles/SubtitlesService.cs
+++ b/sikusiSubtitles/Subtitles/SubtitlesService.cs
@@ -49,9 +49,19 @@ namespace sikusiSubtitles.Subtitles {
             stackPanel.Children.Add(new Image { Source = new BitmapImage(new Uri("pack://application:,,,/Resources/translation.png")) });
             stackPanel.Children.Add(engineNameBox);
             serviceManager.AddStatusBarControl(stackPanel, 200);
+        }
 
-            // 設定ページ
+        /**
+         * サービスの初期化
+         * 音声認識の監視を始める。
+         */
+        public override void Init() {
             settingsPage = new SubtitlesPage(ServiceManager, this);
+            speechRecognitionServiceManager = ServiceManager.GetService<SpeechRecognitionServiceManager>();
+            if (speechRecognitionServiceManager != null) {
+                speechRecognitionServiceManager.Recognizing += RecognizingHandler;
+                speechRecognitionServiceManager.Recognized += RecognizedHandler;
+            }
         }
 
         /** 設定の読み込み */
@@ -84,18 +94,6 @@ namespace sikusiSubtitles.Subtitles {
                 new JProperty("AdditionalClear", AdditionalClear),
                 new JProperty("AdditionalClearTime", AdditionalClearTime),
             };
-        }
-
-        /**
-         * サービスの初期化
-         * 音声認識の監視を始める。
-         */
-        public override void Init() {
-            speechRecognitionServiceManager = ServiceManager.GetService<SpeechRecognitionServiceManager>();
-            if (speechRecognitionServiceManager != null) {
-                speechRecognitionServiceManager.Recognizing += RecognizingHandler;
-                speechRecognitionServiceManager.Recognized += RecognizedHandler;
-            }
         }
 
         /** 音声が読み上げられたら字幕を更新する */

--- a/sikusiSubtitles/Translation/AzureTranslationService.cs
+++ b/sikusiSubtitles/Translation/AzureTranslationService.cs
@@ -19,8 +19,11 @@ namespace sikusiSubtitles.Translation {
         private HttpClient HttpClient = new HttpClient();
 
         public AzureTranslationService(ServiceManager serviceManager) : base(serviceManager, "AzureTranslation", "Azure Cognitive Services", 300) {
-            settingsPage = new AzureTranslationPage(ServiceManager, this);
             this.languages.Sort((a, b) => a.Name.CompareTo(b.Name));
+        }
+
+        public override void Init() {
+            settingsPage = new AzureTranslationPage(ServiceManager, this);
         }
 
         public override void Load(JToken token) {

--- a/sikusiSubtitles/Translation/DeepLTranslationService.cs
+++ b/sikusiSubtitles/Translation/DeepLTranslationService.cs
@@ -15,9 +15,11 @@ namespace sikusiSubtitles.Translation {
 
         public DeepLTranslationService(ServiceManager serviceManager) : base(serviceManager, "DeepL", "DeepL", 400) {
             this.languages.Sort((a, b) => a.Name.CompareTo(b.Name));
-            settingsPage = new DeepLTranslationPage(ServiceManager, this);
         }
 
+        public override void Init() {
+            settingsPage = new DeepLTranslationPage(ServiceManager, this);
+        }
 
         public override void Load(JToken token) {
             Key = Decrypt(token.Value<string>("Key") ?? "");

--- a/sikusiSubtitles/Translation/GoogleAppsScriptTranslationService.cs
+++ b/sikusiSubtitles/Translation/GoogleAppsScriptTranslationService.cs
@@ -17,6 +17,9 @@ namespace sikusiSubtitles.Translation {
         public string Key { get; set; } = "";
 
         public GoogleAppsScriptTranslationService(ServiceManager serviceManager) : base(serviceManager, "GoogleAppsScriptTranslation", "Google Apps Script", 100) {
+        }
+
+        public override void Init() {
             settingsPage = new GoogleAppsScriptTranslationPage(ServiceManager, this);
         }
 

--- a/sikusiSubtitles/Translation/GoogleBasicTranslationService.cs
+++ b/sikusiSubtitles/Translation/GoogleBasicTranslationService.cs
@@ -18,6 +18,9 @@ namespace sikusiSubtitles.Translation {
         public string Key { get; set; } = "";
 
         public GoogleBasicTranslationService(ServiceManager serviceManager) : base(serviceManager, "GoogleBasicTranslation", "Google Cloud Translation", 200) {
+        }
+
+        public override void Init() {
             settingsPage = new GoogleBasicTranslationPage(ServiceManager, this);
         }
 


### PR DESCRIPTION
OBS字幕をOBSの下ではなく字幕の下に移動。